### PR TITLE
v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-google-analytics-bridge",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "React Native bridge for using native Google Analytics libraries on iOS and Android",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
v6.0.0 bump

This version removes TagManager integration, along with bundled dependencies