### PR TITLE
Removed override notation for deprecated method (createJSModules) of React Native 0.47.0

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridgePackage.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridgePackage.java
@@ -33,7 +33,7 @@ public class GoogleAnalyticsBridgePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Cherry-pick of: https://github.com/idehub/react-native-google-analytics-bridge/pull/156

Supports React Native 0.47+ while maintaining backwards compatibility. 