### PR TITLE
Bugfix: Broken gradle imports

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
-    
+
     lintOptions {
         warning 'InvalidPackage' // prevent error: https://github.com/square/okio/issues/58
     }
@@ -18,5 +18,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-analytics:+'
+    compile 'com.google.android.gms:play-services-analytics:12.0.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-google-analytics-bridge",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "React Native bridge for using native Google Analytics libraries on iOS and Android",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
Fixes broken build caused by too-loose dependency 

This locks down our Google Play Services version to solve the build issues discussed in https://github.com/idehub/react-native-google-analytics-bridge/issues/238